### PR TITLE
gives ability to work with branches like 'fix/24-login'

### DIFF
--- a/lib/strano/repo.rb
+++ b/lib/strano/repo.rb
@@ -57,7 +57,7 @@ module Strano
       str = git.branch({:timeout => false, :chdir => path, :base => false}, '-a')
       branches = []
       str.split("\n").each do |br|
-        branch = br.gsub(/\*/, '').strip.split(' ').first.split('/').last
+        branch = br.gsub(/\*/, '').strip.split(' ').first.split('/',3).last
         branches << branch unless branch == 'HEAD'
       end
       branches.uniq


### PR DESCRIPTION
Branch names can contain slashes. We deeply use this feature in our project - we have 'fix','feature' as "namespaces". So almost all our branch has format like <NAMESPACE>/<SHORT_DESC> So I made very simple fix to allow strano to handle this situation as well as usual. Not sure should it be expanded in more complicated code though. 
