### PR TITLE
Fix JS getProject() being called on every pages

### DIFF
--- a/app/assets/javascripts/app/projects.js.coffee
+++ b/app/assets/javascripts/app/projects.js.coffee
@@ -3,7 +3,7 @@ $ ->
   $('.show-task-description').click ->
     $(this).parent().parent().siblings().toggle()
     $(this).text if $(this).text().indexOf('hide') < 0 then 'hide full description >' else 'show full description >'
-    
+
     false
 
 
@@ -19,35 +19,39 @@ $ ->
       $(this).find('small').text 'hide'
       icon.addClass 'ui-icon-circle-triangle-n'
       icon.removeClass 'ui-icon-circle-triangle-s'
-    
+
     div.toggle()
-    
-    
+
+
   # Check that the current project has completed cloning
   getProject = ->
     html = $('#repo-update').html()
-    
-    $.getJSON location, (data) ->
-      
-      if $('#clone-msg').size() > 0
-        if data.cloned_at == null
-          time_diff = new Date() - new Date(data.created_at)
-        
-          # older than 15 minutes and cloning has still not completed.
-          if time_diff > (1000 * 900)
-            msg = "Cloning seems to have failed as it has been running for over 15 minutes now."
-            $('#clone-msg').addClass('error').removeClass('info').text msg
-        else
-          window.location.reload false
-          
-      else if $('#repo-update').size() > 0
-        if data.pull_in_progress == true
-          $('#repo-update').text 'updating...'
-        else
-          $('#repo-update').html html
-          $('#repo-update abbr').text $.timeago(data.pulled_at)
-          $('#repo-update abbr').attr 'title', $.timeago(data.pulled_at)
-          
+    path = location.pathname.split('/')
+    if (path.length == 3 && path[1] == 'projects')
+      project_path = '/projects/' + path[2]
+      $.getJSON project_path, (data) ->
+
+        if $('#clone-msg').size() > 0
+          if data.cloned_at == null
+            time_diff = new Date() - new Date(data.created_at)
+
+            # older than 15 minutes and cloning has still not completed.
+            if time_diff > (1000 * 900)
+              msg = "Cloning seems to have failed as it has been running for over 15 minutes now."
+              $('#clone-msg').addClass('error').removeClass('info').text msg
+          else
+            window.location.reload false
+
+        else if $('#repo-update').size() > 0
+          if data.pull_in_progress == true
+            $('#repo-update').text 'updating...'
+          else
+            $('#repo-update').html html
+            $('#repo-update abbr').text $.timeago(data.pulled_at)
+            $('#repo-update abbr').attr 'title', $.timeago(data.pulled_at)
+
       setTimeout getProject, 5000
-  
-  setTimeout getProject, 5000
+
+  path = location.pathname.split('/')
+  if (path.length == 3 && path[1] == 'projects')
+    setTimeout getProject, 5000


### PR DESCRIPTION
It seems that getProject() was not intended to be called on every page but only on projects/:id (?)
(using the `location` property, makes it query invalid pages like /project/1/jobs/new/deploy.json when called on all pages)
