### PR TITLE
Restrict login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,8 +13,12 @@ class SessionsController < ApplicationController
     attributes = { :github_data => data, :github_access_token => request.env["omniauth.auth"][:credentials][:token] }
     user = User.find_or_create_by_username(data[:login], attributes)
     
-    session[:user_id] = user.id
-    redirect_to root_url, :notice => 'Successfully signed in via Github!'
+    if user.authorized_for_app?
+      session[:user_id] = user.id
+      redirect_to root_url, :notice => 'Successfully signed in via Github!'
+    else
+      redirect_to root_url, :alert => "Access requires organization membership"
+    end
   end
   
   def destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,17 @@ class User < ActiveRecord::Base
     !github.nil?
   end
 
+  # If open_login is set to false in the strano settings, users may only enter if 
+  # they or an organization they belong to is explicitly allowed.
+  # 
+  # Returns a Boolean
+  def authorized_for_app?
+    # authorized if open login is enabled or they're on the members list
+    return true if Strano.open_login || Strano.allow_users_include?(username)
+    
+    # otherwise make a call to github to see if we've allowed any of their organizations
+    github.orgs.any_allowed?
+  end
 
   private
 

--- a/config/strano.example.yml
+++ b/config/strano.example.yml
@@ -36,6 +36,12 @@ defaults: &defaults
   # To only allow project creation from your own repos:
   #
   # allow_users: my_github_username
+  
+  # Set to false to prevent users from accessing the app or creating repos
+  # unless they are listed under allow_users or have membership in an 
+  # organization listed under allow_organizations. Default value is true.
+  # 
+  # open_login: true
 
 development:
   <<: *defaults

--- a/lib/github/orgs.rb
+++ b/lib/github/orgs.rb
@@ -11,6 +11,13 @@ class Github
         yield Github::Org.new(@access_token, org)
       end
     end
+    
+    # Whether the user is a member of any of the allowed organizations
+    #
+    # Returns boolean
+    def any_allowed?
+      all.any? { |org| Strano.allow_organizations_include?(org.login) }
+    end
   
   end
 end

--- a/lib/strano/configuration.rb
+++ b/lib/strano/configuration.rb
@@ -9,7 +9,8 @@ module Strano
       :github_key,
       :github_secret,
       :allow_organizations,
-      :allow_users].freeze
+      :allow_users,
+      :open_login].freeze
 
     # The public SSH key that Strano will add to each users Github account
     # so that Strano can clone github repos locally.
@@ -38,6 +39,12 @@ module Strano
     # creating projects from users completely. Pass an array of Github
     # usernames to restrict which projects Strano can create new projects for.
     DEFAULT_ALLOW_USERS = true
+    
+    # Any user with a Github account can create new deployments. Default
+    # values if true. Setting this to false will only allow users to log in to
+    # the app if they are listed under 'allow_users' or a member of one of the
+    # organizations under 'allow_organizations'.
+    DEFAULT_OPEN_LOGIN = true
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -119,6 +126,7 @@ module Strano
       self.github_secret        = DEFAULT_GITHUB_SECRET
       self.allow_organizations  = DEFAULT_ALLOW_ORGANIZATIONS
       self.allow_users          = DEFAULT_ALLOW_USERS
+      self.open_login           = DEFAULT_OPEN_LOGIN
       self
     end
   end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-Agent: *
-# Disallow: /
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
Correct me if I'm wrong: 
Right now this can only really be deployed behind a firewall or some additional auth, right? Even when repos are restricted to particular organizations or users, _anyone_ with a Github account can log into your Strano installation and use it to fire stuff off using _your_ ssh key.

This commit adds a new configuration option, `open_login`, which restricts users' ability to access the app at all, based on the user's github login or organization membership. This makes it much safer to deploy this excellent app on a publicly accessible server.

Also turned on `disallow /` in robots.txt, for philosophically similar reasons.
