### PR TITLE
Two failed examples in specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+rvm:
+  - 1.9.3
+env:
+  - DB=sqlite
+  - DB=mysql
+script:
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec rake db:test:prepare
+  - bundle exec rake
+before_script:
+  - cp config/database.travis.yml config/database.yml
+  - mysql -e 'create database strano_test'
+  - psql -c 'create database strano_test' -U postgres

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,31 @@
+sqlite: &sqlite
+  adapter: sqlite3
+  database: db/<%= Rails.env %>.sqlite3
+
+mysql: &mysql
+  adapter: mysql2
+  username: root
+  password:
+  database: strano_<%= Rails.env %>
+
+postgresql: &postgresql
+  adapter: postgresql
+  username: postgres
+  password:
+  database: strano_<%= Rails.env %>
+  min_messages: ERROR
+
+defaults: &defaults
+  pool: 5
+  timeout: 5000
+  host: localhost
+  <<: *<%= ENV['DB'] || "postgresql" %>
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -12,7 +12,7 @@ describe Project do
   end
 
   it "should set the github data after save", :vcr => { :cassette_name => 'Github_Repo/_repo' } do
-    @project.github_data.should_not be_empty
+    @project.data.should_not be_empty
   end
 
   describe "#repo", :vcr => { :cassette_name => 'Github_Repo/_repo' } do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ Strano.public_ssh_key = 'stranoshakey'
 Strano.clone_path     = File.join(::Rails.root, '/spec/repos')
 REPO_ROOT = File.expand_path("../repos", __FILE__)
 
+# Create .git folder for dummy repo since we can't have it in actual tree
+STRANO_GIT = "#{REPO_ROOT}/joelmoss/strano/.git"
+Dir.mkdir(STRANO_GIT) unless File.exists?(STRANO_GIT)
+
 RSpec.configure do |config|
   config.mock_with :rspec
 


### PR DESCRIPTION
```
All examples were filtered out; ignoring {:focus=>true}
.....................F....F.......

Failures:

  1) Strano::Repo#cloned? 
    Failure/Error: it { repo.cloned?.should == true }
      expected: true
            got: false (using ==)
    # ./spec/lib/strano/repo_spec.rb:59:in `block (3 levels) in <top (required)>'

  2) Project should set the github data after save
    Failure/Error: @project.github_data.should_not be_empty
    NoMethodError:
      undefined method `github_data' for #<Project:0x0000000a3de348>
    # ./spec/models/project_spec.rb:15:in `block (2 levels) in <top (required)>'

Finished in 12.18 seconds
34 examples, 2 failures

Failed examples:

rspec ./spec/lib/strano/repo_spec.rb:59 # Strano::Repo#cloned? 
rspec ./spec/models/project_spec.rb:14 # Project should set the github data after save
```
