### PR TITLE
Missed .git folder under dummy repository in specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Strano
+Strano [![Build Status](https://secure.travis-ci.org/joelmoss/strano.png?branch=master)](https://travis-ci.org/joelmoss/strano)
 ======
 
 The Github backed Capistrano deployment management UI.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ Strano.public_ssh_key = 'stranoshakey'
 Strano.clone_path     = File.join(::Rails.root, '/spec/repos')
 REPO_ROOT = File.expand_path("../repos", __FILE__)
 
+# Create .git folder for dummy repo since we can't have it in actual tree
+STRANO_GIT = "#{REPO_ROOT}/joelmoss/strano/.git"
+Dir.mkdir(STRANO_GIT) unless File.exists?(STRANO_GIT)
+
 RSpec.configure do |config|
   config.mock_with :rspec
 


### PR DESCRIPTION
Unfortunately we can't have regular `.git` folder under source tree for obvious reason, i.e. it's reserved word
